### PR TITLE
CP-12512 New key _stunnel_legacy "STUNNEL_LEGACY"

### DIFF
--- a/lib/inventory.ml
+++ b/lib/inventory.ml
@@ -34,6 +34,7 @@ let _oem_build_number = "OEM_BUILD_NUMBER"
 let _machine_serial_number = "MACHINE_SERIAL_NUMBER"
 let _machine_serial_name = "MACHINE_SERIAL_NAME"
 let _stunnel_idle_timeout = "STUNNEL_IDLE_TIMEOUT"
+let _stunnel_legacy = "STUNNEL_LEGACY"
 
 let loaded_inventory = ref false
 let inventory = Hashtbl.create 10


### PR DESCRIPTION
Corresponds to Host.ssl_legacy.

This is needed because when a slave starts, it cannot learn its
Host.ssl_legacy without using an stunnel to contact the master to
consult the database.  Therefore a locally stored copy is needed.

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>