### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.0.2 (03-Febr-2017):
+* fix Makfile to make installation via Opam work
+* add Git meta data files .gitarchive-info and .gitattributes
+
 1.0.1 (22-Jun-2016):
 * Update to Stdext 2.0.0
 

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        xcp-inventory
-Version:     1.0.1
+Version:     1.0.2
 Synopsis:    XCP inventory library
 Authors:     Various
 License:     LGPL-2.1 with OCaml linking exception


### PR DESCRIPTION
The previous commit was tagged as v1.0.2 but we forgot to update the
_oasis file and the ChangeLog. This commit adds these changes.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>